### PR TITLE
Day4: Login using routes and not ui

### DIFF
--- a/cypress/e2e/login.spec.cy.js
+++ b/cypress/e2e/login.spec.cy.js
@@ -12,7 +12,8 @@ describe('login', () => {
         cy.get('#password').type('s3cret')
         cy.get('[data-test="signin-submit"]').should('be.enabled').click()
 
-        cy.url().should('not.contain', '/signin')
+        //cy.url().should('not.contain', '/signin')
+        cy.location('pathname').should('equal','/')
         cy.get('[data-test="sidenav-username"]').should('have.text', '@Allie2')
     })
 
@@ -31,10 +32,6 @@ describe('login', () => {
 
     // Day 1 - new tests based on learnings from day 1
 
-    it('login without remember me, logout and ensure direct visit navigates to signin page', () => {
-        
-    });
-
     it('sign in, select Remember me, validate remember is true in login request', () => {
         cy.get('#username').type('Allie2')
         cy.get('#password').type('s3cret')
@@ -48,6 +45,7 @@ describe('login', () => {
             expect(xhr.request.body['remember']).to.match(/true/)
         })
 
-        cy.url().should('not.contain', '/signin')
+        // cy.url().should('not.contain', '/signin')
+        cy.location('pathname').should('equal', '/')
     });
 })


### PR DESCRIPTION
## Summary

Add changes based on Day3 and Day4 of the autobots-cypress course. 
Refer to the following for more details:
* [Day3](https://iheartjs.dev/day-3/)
* [Day4](https://iheartjs.dev/day-4/)

## Description & motivation
Adds support for the following:

* Using cy.location instead of cy.url()
* Wait on network get requests performed after login post to ensure all network return are successful
* Validate login post request body

## Validation

√  login.spec.cy.js                         00:06        3        3        -        -        -
√  signup.spec.cy.js                        00:08        1        1        -        -        -
√  All specs passed!                        00:15        4        4        -        -        -
